### PR TITLE
Merge nightly features into master

### DIFF
--- a/lua/core/plugin_configs/lsp.lua
+++ b/lua/core/plugin_configs/lsp.lua
@@ -41,7 +41,7 @@ function InitLspPlugin()
                 name = "LSP", -- optional group name
                 a = { vim.lsp.buf.code_action, "Code Actions" },
                 A = { vim.lsp.codelens.run, "CodeLens Action" },
-                d = { vim.lsp.buf.definition, "Definition" },
+                d = { vim.diagnostic.open_float, "Line Diagnostic" },
                 t = { vim.lsp.buf.type_definition, "Type Definition" },
                 T = {
                     name = "Toggle",
@@ -111,6 +111,3 @@ function InitLspPlugin()
 end
 
 if not vim.g.vscode then InitLspPlugin() end
-
-vim.keymap.set("n", "]g", vim.diagnostic.goto_next, { desc = "Next diagnostic" })
-vim.keymap.set("n", "[g", vim.diagnostic.goto_prev, { desc = "Previous diagnostic" })

--- a/lua/core/plugin_configs/lsp.lua
+++ b/lua/core/plugin_configs/lsp.lua
@@ -1,6 +1,21 @@
 -- Initialise LSP plugin
 
 function InitLspPlugin()
+    -- Enable inlay hints
+    vim.api.nvim_create_autocmd("LspAttach", {
+        group = vim.api.nvim_create_augroup("UserLspConfig", {}),
+        callback = function(args)
+            local client = vim.lsp.get_client_by_id(args.data.client_id)
+            if client ~= nil and client.server_capabilities.codeLensProvider then
+                vim.lsp.codelens.refresh()
+            end
+            if client ~= nil and client.server_capabilities.inlayHintProvider then
+                vim.lsp.inlay_hint.enable(true)
+            end
+            -- whatever other lsp config you want
+        end
+    })
+
     local lspZero = require('lsp-zero').preset({})
 
     lspZero.on_attach(function(client, bufnr)
@@ -14,6 +29,7 @@ function InitLspPlugin()
             l = {
                 name = "LSP", -- optional group name
                 a = { vim.lsp.buf.code_action, "Code Actions" },
+                A = { vim.lsp.codelens.run, "CodeLens Action" },
                 d = { vim.lsp.buf.definition, "Definition" },
                 t = { vim.lsp.buf.type_definition, "Type Definition" },
                 h = { vim.lsp.buf.hover, "Hover" },

--- a/lua/core/plugin_configs/lsp.lua
+++ b/lua/core/plugin_configs/lsp.lua
@@ -1,5 +1,16 @@
--- Initialise LSP plugin
+-- Util functions
+local function toggleInlayHints()
+    if vim.fn.has "nvim-0.10" == 1 then
+        local ok = pcall(vim.lsp.inlay_hint.enable, vim.lsp.inlay_hint.is_enabled())
+        if ok then
+            vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled())
+        else
+            vim.lsp.inlay_hint.enable(0, not vim.lsp.inlay_hint.is_enabled())
+        end
+    end
+end
 
+-- Initialise LSP plugin
 function InitLspPlugin()
     -- Enable inlay hints
     vim.api.nvim_create_autocmd("LspAttach", {
@@ -32,7 +43,10 @@ function InitLspPlugin()
                 A = { vim.lsp.codelens.run, "CodeLens Action" },
                 d = { vim.lsp.buf.definition, "Definition" },
                 t = { vim.lsp.buf.type_definition, "Type Definition" },
-                h = { vim.lsp.buf.hover, "Hover" },
+                T = {
+                    name = "Toggle",
+                    h = { toggleInlayHints, "Toggle Inlay Hints" },
+                },
                 s = {
                     name = "Symbols",
                     w = { telescopeBuiltin.lsp_dynamic_workspace_symbols, "Workspace" },


### PR DESCRIPTION
Now that the stable version of nvim has crossed v0.10, it supports the features configured on the nightly branch. 

Features like:
1. Codelens
2. InlayHints

So until I need other features introduced by the newer version of nightly nvim, this branch can be merged with master.